### PR TITLE
Adding Plugin Emulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 - [Retrieval Demo (MP4 file)](https://cdn.openai.com/chat-plugins/retrieval-gh-repo-readme/Retrieval-Final.mp4)
 - [On-demand video processing](https://twitter.com/gdb/status/1638971232443076609)
 - [Summarizing a HackerNews thread](https://twitter.com/gdb/status/1638986918947082241)
+- [Emulator for Plugins](https://play.chatplugin.app)
 
 ### Creating a plugin:
 - [Full documentation](https://platform.openai.com/docs/plugins/introduction)


### PR DESCRIPTION
In this PR I am adding [play.chatplugin.app](https://play.chatplugin.app) which is the beginning of a development framework for Chat AI Plugins. 

The goal is to have a cross-AI emulator and testing tool. You could also share it to your clients if you are a plugin developer

If you have a suggestion for a better spot, let me know. 

I think a special section could make sense, like Development tools, because that is what I am building right now